### PR TITLE
Test with --add-exports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,8 +127,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.12.1</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <source>21</source>
+          <target>21</target>
           <compilerArgs>
             <arg>--add-exports</arg>
             <arg>jdk.jconsole/sun.tools.jconsole=ALL-UNNAMED</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.12.1</version>
         <configuration>
-          <source>8</source>
+          <source>11</source>
           <target>11</target>
           <compilerArgs>
             <arg>--add-exports</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -123,8 +123,22 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.12.1</version>
+        <configuration>
+          <source>8</source>
+          <target>11</target>
+          <compilerArgs>
+            <arg>--add-exports</arg>
+            <arg>jdk.jconsole/sun.tools.jconsole=ALL-UNNAMED</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>default-jar</id>
@@ -135,7 +149,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.3</version>
         <configuration>
           <show>protected</show>
           <failOnError>true</failOnError>
@@ -143,7 +157,9 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <phase>prepare-package</phase>
@@ -160,6 +176,9 @@
                 <manifest>
                   <mainClass>org.cyclopsgroup.jmxterm.boot.CliMain</mainClass>
                 </manifest>
+                <manifestEntries>
+                  <Add-Exports>jdk.jconsole/sun.tools.jconsole</Add-Exports>
+                </manifestEntries>
               </archive>
             </configuration>
           </execution>
@@ -168,6 +187,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
         <configuration>
           <excludes>
             <exclude>org.cyclopsgroup.jmxterm.jdk*</exclude>


### PR DESCRIPTION
Fixes crash when running the `jvms` command on Java 9+ (some versions showed just a warning, i.e. illegal reflective access operation has occurred).

JAR can be run with `java -jar target/jmxter-1.0.4-uber.jar` without `--add-exports` (thanks to `Add-Exports` added in the MANIFEST file).

However, this fix drops compatibility with Java 8 and `--add-exports` can't be used with release option of the compiler plugin.

See also: https://stackoverflow.com/questions/75239006/how-do-i-give-jmxterm-access-to-sun-tools-jconsole-localvirtualmachine-in-java-1